### PR TITLE
define `nam_dll_version` in Lua

### DIFF
--- a/src/NAMDllDirector.cpp
+++ b/src/NAMDllDirector.cpp
@@ -438,6 +438,16 @@ public:
 		if (gameVersion == 641)
 		{
 			InstallMemoryPatches(gameVersion);
+
+			cIGZFrameWork* const pFramework = RZGetFrameWork();
+			if (pFramework->GetState() < cIGZFrameWork::kStatePreAppInit)
+			{
+				pFramework->AddHook(this);
+			}
+			else
+			{
+				PreAppInit();
+			}
 		}
 		else
 		{
@@ -447,18 +457,6 @@ public:
 				"The memory patches require game version 641, found game version %d.",
 				gameVersion);
 		}
-
-		cIGZFrameWork* const pFramework = RZGetFrameWork();
-
-		if (pFramework->GetState() < cIGZFrameWork::kStatePreAppInit)
-		{
-			pFramework->AddHook(this);
-		}
-		else
-		{
-			PreAppInit();
-		}
-
 		return true;
 	}
 

--- a/src/NAMDllDirector.cpp
+++ b/src/NAMDllDirector.cpp
@@ -35,6 +35,9 @@
 #include "cIGZWin.h"
 #include "cIGZWinMgr.h"
 #include "cISC4App.h"
+#include "cISC4City.h"
+#include "cISC4AdvisorSystem.h"
+#include "cISCLua.h"
 #include "cISC4View3DWin.h"
 #include "cRZMessage2COMDirector.h"
 #include "GZServPtrs.h"
@@ -307,9 +310,33 @@ public:
 		}
 	}
 
+	void RegisterDllVersionInLua() {
+		cISC4AppPtr pApp;
+		if (!pApp) {
+			return;
+		}
+		cISC4City* pCity = pApp->GetCity();
+		if (pCity)
+		{
+			cISC4AdvisorSystem* pAdvisorSystem = pCity->GetAdvisorSystem();
+			if (pAdvisorSystem)
+			{
+				cISCLua* const pLua = pAdvisorSystem->GetScriptingContext();
+				if (pLua)
+				{
+					const char* const kVersionVariableName = "nam_dll_version";
+					const std::string_view& version_str = PLUGIN_VERSION_STR;
+					pLua->PushLString(version_str.data(), version_str.size());
+					pLua->SetGlobal(kVersionVariableName);
+				}
+			}
+		}
+	}
+
 	void PostCityInit(cIGZMessage2Standard* pStandardMessage)
 	{
 		RegisterKeyboardShortcuts();
+		RegisterDllVersionInLua();
 	}
 
 	void ProcessKeyboardShortcut(uint32_t dwMessageID)


### PR DESCRIPTION
This adds the DLL version string as a global Lua variable `nam_dll_version` for use by the advisor system.

The gzcom library is upgraded to the current version to be able to use the Lua headers.

Additionally, this PR limits usage of the GZ-Framework to game version 641, as NAM 50 will require DLL functionality that depends on version 641. (Effectively, this means that the custom keyboard shortcuts won't work with the unsupported game version 640 anymore.)