### PR TITLE
implement fixes for network slopes

### DIFF
--- a/src/NAMDllDirector.cpp
+++ b/src/NAMDllDirector.cpp
@@ -46,12 +46,7 @@
 #include "wil/win32_helpers.h"
 #include "Patching.h"
 #include "Rul2Engine.h"
-
-#ifdef __clang__
-#define NAKED_FUN __attribute__((naked))
-#else
-#define NAKED_FUN __declspec(naked)
-#endif
+#include "NetworkSlopes.h"
 
 static constexpr uint32_t kNAMDllDirectorID = 0x4AC2AEFF;
 
@@ -249,12 +244,14 @@ noMatchingTunnelNetwork:
 		InstallFerryBridgeHeightPatch();
 		InstallTunnelsPatch(gameVersion);
 		try {
+			logger.WriteLine(LogLevel::Info, "Installing the RUL2 Engine patch.");
 			Rul2Engine::Install();
-			logger.WriteLine(LogLevel::Info, "Installed the RUL2 Engine patch.");
+			logger.WriteLine(LogLevel::Info, "Installing the Network Slopes patch.");
+			NetworkSlopes::Install();
 		}
 		catch (const wil::ResultException& e)
 		{
-			logger.WriteLineFormatted(LogLevel::Error, "Failed to install the RUL2 Engine patch.\n%s", e.what());
+			logger.WriteLineFormatted(LogLevel::Error, "Failed to install the last patch.\n%s", e.what());
 		}
 	}
 }

--- a/src/NetworkSlopes.cpp
+++ b/src/NetworkSlopes.cpp
@@ -2,31 +2,81 @@
 #include "Patching.h"
 #include "Logger.h"
 #include "NetworkStubs.h"
+#include <algorithm>
 
 namespace
 {
+	uint32_t countConnections(uint32_t edgeFlags, uint8_t mask) {
+		uint32_t m = mask & 0xff;
+		return
+			((edgeFlags & m << 24) != 0) +
+			((edgeFlags & m << 16) != 0) +
+			((edgeFlags & m <<  8) != 0) +
+			((edgeFlags & m      ) != 0);
+	}
+
+	bool isPureDiag(uint32_t edgeFlags) {
+		return edgeFlags == 0x03010000 || edgeFlags == 0x00030100 || edgeFlags == 0x00000301 || edgeFlags == 0x01000003;
+	}
+
+	bool isPureOrth(uint32_t edgeFlags) {
+		return (edgeFlags & ~0x00040004) == 0x02000200 || (edgeFlags & ~0x04000400) == 0x00020002;
+	}
+
+	// estimate whether this likely is an orthogonal (or diagonal) falsie with respect to first network
+	bool isFalsieFirst(uint32_t edgeFlags1, uint32_t edgeFlags2, bool diag) {
+		if (diag ? isPureDiag(edgeFlags1) : isPureOrth(edgeFlags1)) {
+			auto numConns2 = countConnections(edgeFlags2, 0xff);
+			if (numConns2 >= 3 || numConns2 == 2 && !isPureOrth(edgeFlags2) && !isPureDiag(edgeFlags2)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	void insertSlopeAndSmoothnessConstraints(cSC4NetworkTool* networkTool, cSC4NetworkCellInfo &cellInfo)
 	{
 		// cell is not immovable and not null
 		auto networkType = cSC4NetworkTool::GetFirstNetworkTypeFromFlags(cellInfo.networkTypeFlags);
-		uint32_t numBasicConns =
-			((cellInfo.edgeFlagsCombined & 0x03000000) != 0) +
-			((cellInfo.edgeFlagsCombined & 0x00030000) != 0) +
-			((cellInfo.edgeFlagsCombined & 0x00000300) != 0) +
-			((cellInfo.edgeFlagsCombined & 0x00000003) != 0);
+		uint32_t numBasicConnsCombined = countConnections(cellInfo.edgeFlagsCombined, 0x03);
 		bool isMultiType = (cellInfo.networkTypeFlags & cellInfo.networkTypeFlags - 1) != 0;
-		bool forceFlattenIntersection =
-			(numBasicConns == 0 || numBasicConns > 2)
-			&& (isMultiType || cellInfo.edgeFlagsCombined != 0x3010301 && cellInfo.edgeFlagsCombined != 0x1030103);
-		if (forceFlattenIntersection ||
-				!cSC4NetworkTool::sNetworkTypeInfo[networkType].pylonSupportIDs.empty() &&
-				(cellInfo.edgeFlagsCombined & 0xf8f8f8f8) != 0 && numBasicConns == 2)  // special higher-flag Lightrail/Monorail pieces
+
+		bool isFalsie = false;
+		if (isMultiType && !cellInfo.isNetworkLot) {
+			auto networkType2 = cSC4NetworkTool::GetFirstNetworkTypeFromFlags(cellInfo.networkTypeFlags & cellInfo.networkTypeFlags - 1);
+			auto edgeFlags1 = cellInfo.edgesPerNetwork[networkType];
+			auto edgeFlags2 = cellInfo.edgesPerNetwork[networkType2];
+			if (isFalsieFirst(edgeFlags1, edgeFlags2, false)) {  // orth
+				isFalsie = true;
+			} else if (isFalsieFirst(edgeFlags2, edgeFlags1, false)) {  // orth
+				isFalsie = true;
+				std::swap(networkType, networkType2);
+				std::swap(edgeFlags1, edgeFlags2);
+			} else if (isFalsieFirst(edgeFlags1, edgeFlags2, true)) {  // diag
+				isFalsie = true;
+			} else if (isFalsieFirst(edgeFlags2, edgeFlags1, true)) {  // diag
+				isFalsie = true;
+				std::swap(networkType, networkType2);
+				std::swap(edgeFlags1, edgeFlags2);
+			} else {
+				// not a falsie
+			}
+		}
+
+		if (!isFalsie && (
+			(numBasicConnsCombined == 0 || numBasicConnsCombined > 2)
+			&& (isMultiType || cellInfo.edgeFlagsCombined != 0x3010301 && cellInfo.edgeFlagsCombined != 0x1030103)  // intersections, regardless of number of networks
+			|| !cSC4NetworkTool::sNetworkTypeInfo[networkType].pylonSupportIDs.empty()
+			&& (cellInfo.edgeFlagsCombined & 0xf8f8f8f8) != 0 && numBasicConnsCombined == 2  // special higher-flag Lightrail/Monorail pieces
+			))
 		{
 			uint32_t networkLotOffset = cellInfo.isNetworkLot != false ? 100000 : 0;
 			networkTool->InsertEqualityConstraint(cellInfo.vertexNW + networkLotOffset, cellInfo.vertexSW + networkLotOffset);
 			networkTool->InsertEqualityConstraint(cellInfo.vertexSW + networkLotOffset, cellInfo.vertexSE + networkLotOffset);
 			networkTool->InsertEqualityConstraint(cellInfo.vertexSE + networkLotOffset, cellInfo.vertexNE + networkLotOffset);
-		} else {
+		}
+		else
+		{
 			cSC4NetworkTool::tCrossSection csA, csB, csC;
 			bool isDiag;
 			for (int32_t dir = 0; dir < 4; dir++) {

--- a/src/NetworkSlopes.cpp
+++ b/src/NetworkSlopes.cpp
@@ -1,0 +1,73 @@
+#include "NetworkSlopes.h"
+#include "Patching.h"
+#include "Logger.h"
+#include "NetworkStubs.h"
+
+namespace
+{
+	void insertSlopeAndSmoothnessConstraints(cSC4NetworkTool* networkTool, cSC4NetworkCellInfo &cellInfo)
+	{
+		// cell is not immovable and not null
+		auto networkType = cSC4NetworkTool::GetFirstNetworkTypeFromFlags(cellInfo.networkTypeFlags);
+		uint32_t numBasicConns =
+			((cellInfo.edgeFlagsCombined & 0x03000000) != 0) +
+			((cellInfo.edgeFlagsCombined & 0x00030000) != 0) +
+			((cellInfo.edgeFlagsCombined & 0x00000300) != 0) +
+			((cellInfo.edgeFlagsCombined & 0x00000003) != 0);
+		bool isMultiType = (cellInfo.networkTypeFlags & cellInfo.networkTypeFlags - 1) != 0;
+		bool forceFlattenIntersection =
+			(numBasicConns == 0 || numBasicConns > 2)
+			&& (isMultiType || cellInfo.edgeFlagsCombined != 0x3010301 && cellInfo.edgeFlagsCombined != 0x1030103);
+		if (forceFlattenIntersection ||
+				!cSC4NetworkTool::sNetworkTypeInfo[networkType].pylonSupportIDs.empty() &&
+				(cellInfo.edgeFlagsCombined & 0xf8f8f8f8) != 0 && numBasicConns == 2)  // special higher-flag Lightrail/Monorail pieces
+		{
+			uint32_t networkLotOffset = cellInfo.isNetworkLot != false ? 100000 : 0;
+			networkTool->InsertEqualityConstraint(cellInfo.vertexNW + networkLotOffset, cellInfo.vertexSW + networkLotOffset);
+			networkTool->InsertEqualityConstraint(cellInfo.vertexSW + networkLotOffset, cellInfo.vertexSE + networkLotOffset);
+			networkTool->InsertEqualityConstraint(cellInfo.vertexSE + networkLotOffset, cellInfo.vertexNE + networkLotOffset);
+		} else {
+			cSC4NetworkTool::tCrossSection csA, csB, csC;
+			bool isDiag;
+			for (int32_t dir = 0; dir < 4; dir++) {
+				if (networkTool->GetCrossSections(cellInfo, networkType, dir, csA, csB, csC, isDiag)) {
+					auto slope = isDiag ? cSC4NetworkTool::sNetworkTypeInfo[networkType].slopeDiag : cSC4NetworkTool::sNetworkTypeInfo[networkType].slopeOrth;
+					auto smoothness = isDiag ? cSC4NetworkTool::sNetworkTypeInfo[networkType].smoothnessDiag : cSC4NetworkTool::sNetworkTypeInfo[networkType].smoothnessOrth;
+					networkTool->InsertEqualityConstraint(csA.vertex1, csA.vertex2);
+					networkTool->InsertEqualityConstraint(csB.vertex1, csB.vertex2);
+					networkTool->InsertEqualityConstraint(csC.vertex1, csC.vertex2);
+					networkTool->InsertSlopeConstraint(csB.vertex1, csA.vertex1, slope);
+					networkTool->InsertSlopeConstraint(csA.vertex1, csC.vertex1, slope);
+					networkTool->InsertSmoothnessConstraint(csB.vertex1, csA.vertex1, csC.vertex1, smoothness);
+				}
+			}
+		}
+	}
+
+	constexpr uint32_t InsertSlopeAndSmoothnessConstraintsForCell_InjectPoint = 0x6366c5;
+	constexpr uint32_t InsertSlopeAndSmoothnessConstraintsForCell_ReturnJump = 0x636907;
+
+	void NAKED_FUN Hook_InsertSlopeAndSmoothnessConstraintsForCell(void)
+	{
+		__asm {
+			push eax;  // store
+			push ecx;  // store
+			push edx;  // store
+			push ebx;  // cellInfo
+			push ebp;  // networkTool
+			call insertSlopeAndSmoothnessConstraints;  // (cdecl)
+			add esp, 0x8;
+			pop edx;  // restore
+			pop ecx;  // restore
+			pop eax;  // restore
+			push InsertSlopeAndSmoothnessConstraintsForCell_ReturnJump;
+			ret;
+		}
+	}
+
+}
+
+void NetworkSlopes::Install()
+{
+	Patching::InstallHook(InsertSlopeAndSmoothnessConstraintsForCell_InjectPoint, Hook_InsertSlopeAndSmoothnessConstraintsForCell);
+}

--- a/src/NetworkSlopes.cpp
+++ b/src/NetworkSlopes.cpp
@@ -1,11 +1,109 @@
 #include "NetworkSlopes.h"
 #include "Patching.h"
-#include "Logger.h"
 #include "NetworkStubs.h"
 #include <algorithm>
+#include <unordered_map>
+#include <functional>
+#include <bit>
+#include "RotFlip.h"
+
+#define NW_MASK(n) (1 << cISC4NetworkOccupant::eNetworkType::n)
+
+struct IntersectionFlags {
+	uint32_t networkTypeFlags;
+	uint32_t edgeFlags1;
+	uint32_t edgeFlags2;
+	bool operator==(const IntersectionFlags&) const = default;
+};
+template<> struct std::hash<IntersectionFlags>
+{
+	std::size_t operator()(const IntersectionFlags &s) const noexcept
+	{
+		std::size_t h = 5381;
+		h = ((h << 5) + h) + std::hash<uint32_t>{}(s.networkTypeFlags);
+		h = ((h << 5) + h) + std::hash<uint32_t>{}(s.edgeFlags1);
+		h = ((h << 5) + h) + std::hash<uint32_t>{}(s.edgeFlags2);
+		return h;
+	}
+};
 
 namespace
 {
+	enum CellCorner : uint8_t { NW = 0, SW = 1, SE = 2, NE = 3 };
+
+	// apply rotation/flip to vertex corners 0:NW, 1:SW, 2:SE, 3:NE
+	constexpr CellCorner rotateCorner(CellCorner corner, RotFlip rf) {
+		return static_cast<CellCorner>(((corner - (rf & 0x3)) & 0x3) ^ (rf >> 6 | rf >> 7));
+	}
+
+	enum CellSide : uint8_t { West = 0, North = 1, East = 2, South = 3 };
+
+	constexpr CellSide rotateSide(CellSide side, RotFlip rf) {
+		uint8_t x = ((uint8_t) side + (uint8_t) rf) & 0x3;
+		return static_cast<CellSide>(isFlipped(rf)
+				? (x * 3 + 2) & 0x3  // switch 0 and 2, keep 1 and 3
+				: x);
+	}
+
+	struct OnslopeSpec {
+		CellSide groundSide;
+		float height;
+		bool firstIsMain;
+	};
+
+	constexpr float roadHtL1 = 7.5, roadHtL2 = 15.0;
+	constexpr float railHtL1 = 7.5, railHtL2 = 15.5;
+
+	// the flags must have the same order as in RUL1 (so must not be swapped)
+	const std::unordered_map<IntersectionFlags, OnslopeSpec> onslopePiecesPartial = {
+		// viaducts
+		{{NW_MASK(Road)      | NW_MASK(DirtRoad),   0x00040004, 0x00020001}, {West, roadHtL1,  true}},  // L1 Road OST
+		{{NW_MASK(Road)      | NW_MASK(DirtRoad),   0x00040004, 0x00020003}, {West, roadHtL2,  true}},  // L2 Road OST
+		{{NW_MASK(Rail)      | NW_MASK(OneWayRoad), 0x00040000, 0x00020002}, {West, roadHtL1, false}},  // L1 OWR OST
+		{{NW_MASK(LightRail) | NW_MASK(OneWayRoad), 0x00040000, 0x00020002}, {West, roadHtL2, false}},  // L2 OWR OST
+		{{NW_MASK(Avenue)    | NW_MASK(DirtRoad),   0x04040004, 0x00020001}, {West, roadHtL1,  true}},  // L1 Avenue OST
+		{{NW_MASK(Avenue)    | NW_MASK(DirtRoad),   0x00040404, 0x00020003}, {West, roadHtL1,  true}},  // L1 Avenue OST flipped
+		{{NW_MASK(Avenue)    | NW_MASK(DirtRoad),   0x04040004, 0x00010002}, {West, roadHtL2,  true}},  // L2 Avenue OST
+		{{NW_MASK(Avenue)    | NW_MASK(DirtRoad),   0x00040404, 0x00030002}, {West, roadHtL2,  true}},  // L2 Avenue OST flipped
+		// RHW
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040000, 0x00020002}, {West, roadHtL1, false}},  // L1 RHW2 OST
+		{{NW_MASK(Monorail)  | NW_MASK(DirtRoad),   0x00040000, 0x00020002}, {West, roadHtL2, false}},  // L2 RHW2 OST
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00000004, 0x00000401}, {West, roadHtL1, false}},  // L1 RHW2 OST diag lower
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00000004, 0x04000003}, {West, roadHtL1, false}},  // L1 RHW2 OST diag lower flipped
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x04040400, 0x04010000}, {West, roadHtL1, false}},  // L1 RHW2 OST diag upper
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x04040400, 0x00030400}, {West, roadHtL1, false}},  // L1 RHW2 OST diag upper flipped
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040000, 0x00000401}, {West, roadHtL2, false}},  // L2 RHW2 OST diag lower
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040000, 0x04000003}, {West, roadHtL2, false}},  // L2 RHW2 OST diag lower flipped
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040004, 0x04010000}, {West, roadHtL2, false}},  // L2 RHW2 OST diag upper
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040004, 0x00030400}, {West, roadHtL2, false}},  // L2 RHW2 OST diag upper flipped
+		// Rail
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040404, 0x00020002}, {West, railHtL1,  true}},  // L1 Rail OST
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040402, 0x00020000}, {West, railHtL2,  true}},  // L2 Rail OST
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x04040400, 0x03010000}, {West, railHtL1,  true}},  // L1 Rail OST diag upper
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x04040400, 0x00030100}, {West, railHtL1,  true}},  // L1 Rail OST diag upper flipped
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00000304, 0x03010000}, {West, railHtL1,  true}},  // L1 Rail OST diag lower
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x01000004, 0x00030100}, {West, railHtL1,  true}},  // L1 Rail OST diag lower flipped
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x03040004, 0x00010000}, {West, railHtL2,  true}},  // L2 Rail OST diag upper
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040104, 0x00030000}, {West, railHtL2,  true}},  // L2 Rail OST diag upper flipped
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040301, 0x03010000}, {West, railHtL2,  true}},  // L2 Rail OST diag lower
+		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x01040003, 0x00030100}, {West, railHtL2,  true}},  // L2 Rail OST diag lower flipped
+		// HRW
+		{{NW_MASK(Rail)      | NW_MASK(Monorail),   0x04020402, 0x02040304}, {West, railHtL1,  true}},  // L1 HRW OST (orth and diag)
+		{{NW_MASK(Rail)      | NW_MASK(Monorail),   0x04020402, 0x01040204}, {West, railHtL2,  true}},  // L2 HRW OST (orth and diag)
+	};
+
+	std::unordered_map<IntersectionFlags, OnslopeSpec> initOnslopePiecesWithRotations() {
+		std::unordered_map<IntersectionFlags, OnslopeSpec> onslopePieces = {};
+		for (auto const& [key, value] : onslopePiecesPartial) {
+			onslopePieces[key] = value;
+			onslopePieces[{key.networkTypeFlags, std::rotl(key.edgeFlags1,  8), std::rotl(key.edgeFlags2,  8)}] = {rotateSide(value.groundSide, R1F0), value.height, value.firstIsMain};
+			onslopePieces[{key.networkTypeFlags, std::rotl(key.edgeFlags1, 16), std::rotl(key.edgeFlags2, 16)}] = {rotateSide(value.groundSide, R2F0), value.height, value.firstIsMain};
+			onslopePieces[{key.networkTypeFlags, std::rotl(key.edgeFlags1, 24), std::rotl(key.edgeFlags2, 24)}] = {rotateSide(value.groundSide, R3F0), value.height, value.firstIsMain};
+		}
+		return onslopePieces;
+	}
+	const std::unordered_map<IntersectionFlags, OnslopeSpec> onslopePieces = initOnslopePiecesWithRotations();
+
 	uint32_t countConnections(uint32_t edgeFlags, uint8_t mask) {
 		uint32_t m = mask & 0xff;
 		return
@@ -13,6 +111,10 @@ namespace
 			((edgeFlags & m << 16) != 0) +
 			((edgeFlags & m <<  8) != 0) +
 			((edgeFlags & m      ) != 0);
+	}
+
+	bool isMultiType(const cSC4NetworkCellInfo &cellInfo) {
+		return (cellInfo.networkTypeFlags & cellInfo.networkTypeFlags - 1) != 0;
 	}
 
 	bool isPureDiag(uint32_t edgeFlags) {
@@ -34,19 +136,45 @@ namespace
 		return false;
 	}
 
+	constexpr uint32_t mkCellXZ(const uint32_t &x, const uint32_t &z) {
+		return z * 0x10000 + x;
+	}
+
+	// determine the xz cell coordinate of the cell containing the cross section vertices
+	bool diagCrossSectionToCellXZ(const cSC4NetworkTool::tCrossSection &cs, const uint32_t &numCellsX, const uint32_t &numCellsZ, uint32_t &xz) {
+		auto totalVerts = (numCellsX + 1) * (numCellsZ + 1);
+		if (cs.vertex1 < 0 || cs.vertex1 >= totalVerts || cs.vertex2 < 0 || cs.vertex2 >= totalVerts) {
+			return false;
+		} else {
+			auto div1 = std::div(cs.vertex1, numCellsX + 1);
+			auto div2 = std::div(cs.vertex2, numCellsX + 1);
+			xz = mkCellXZ(std::min(div1.rem, div2.rem), std::min(div1.quot, div2.quot));
+			return true;
+		}
+	}
+
 	void insertSlopeAndSmoothnessConstraints(cSC4NetworkTool* networkTool, cSC4NetworkCellInfo &cellInfo)
 	{
 		// cell is not immovable and not null
 		auto networkType = cSC4NetworkTool::GetFirstNetworkTypeFromFlags(cellInfo.networkTypeFlags);
 		uint32_t numBasicConnsCombined = countConnections(cellInfo.edgeFlagsCombined, 0x03);
-		bool isMultiType = (cellInfo.networkTypeFlags & cellInfo.networkTypeFlags - 1) != 0;
+		bool isMulti = isMultiType(cellInfo);
 
+		// check if cell is onslope or falsie
 		bool isFalsie = false;
-		if (isMultiType && !cellInfo.isNetworkLot) {
+		const OnslopeSpec* onslopeSpec;
+		if (isMulti && !cellInfo.isNetworkLot) {
 			auto networkType2 = cSC4NetworkTool::GetFirstNetworkTypeFromFlags(cellInfo.networkTypeFlags & cellInfo.networkTypeFlags - 1);
 			auto edgeFlags1 = cellInfo.edgesPerNetwork[networkType];
 			auto edgeFlags2 = cellInfo.edgesPerNetwork[networkType2];
-			if (isFalsieFirst(edgeFlags1, edgeFlags2, false)) {  // orth
+			IntersectionFlags key = {.networkTypeFlags = cellInfo.networkTypeFlags, .edgeFlags1 = edgeFlags1, .edgeFlags2 = edgeFlags2};
+			if (auto search = onslopePieces.find(key); search != onslopePieces.end()) {
+				onslopeSpec = &search->second;
+				if (!onslopeSpec->firstIsMain) {
+					std::swap(networkType, networkType2);
+					std::swap(edgeFlags1, edgeFlags2);
+				}
+			} else if (isFalsieFirst(edgeFlags1, edgeFlags2, false)) {  // orth
 				isFalsie = true;
 			} else if (isFalsieFirst(edgeFlags2, edgeFlags1, false)) {  // orth
 				isFalsie = true;
@@ -59,24 +187,60 @@ namespace
 				std::swap(networkType, networkType2);
 				std::swap(edgeFlags1, edgeFlags2);
 			} else {
-				// not a falsie
+				// neither falsie nor onslope
 			}
 		}
 
-		if (!isFalsie && (
+		if (onslopeSpec != nullptr)
+		{
+			// larger slope tolerance for onslope pieces
+			auto slope = cSC4NetworkTool::sNetworkTypeInfo[networkType].slopeOrth + onslopeSpec->height;
+			if (onslopeSpec->groundSide == West || onslopeSpec->groundSide == East) {  // x-axis
+				networkTool->InsertEqualityConstraint(cellInfo.vertices[NW], cellInfo.vertices[SW]);
+				networkTool->InsertEqualityConstraint(cellInfo.vertices[NE], cellInfo.vertices[SE]);
+				networkTool->InsertSlopeConstraint(cellInfo.vertices[SW], cellInfo.vertices[SE], slope);
+			} else {  // z-axis
+				networkTool->InsertEqualityConstraint(cellInfo.vertices[SE], cellInfo.vertices[SW]);
+				networkTool->InsertEqualityConstraint(cellInfo.vertices[NE], cellInfo.vertices[NW]);
+				networkTool->InsertSlopeConstraint(cellInfo.vertices[SE], cellInfo.vertices[NE], slope);
+			}
+		}
+		else if (!isFalsie && (
 			(numBasicConnsCombined == 0 || numBasicConnsCombined > 2)
-			&& (isMultiType || cellInfo.edgeFlagsCombined != 0x3010301 && cellInfo.edgeFlagsCombined != 0x1030103)  // intersections, regardless of number of networks
+			&& (isMulti || cellInfo.edgeFlagsCombined != 0x3010301 && cellInfo.edgeFlagsCombined != 0x1030103)  // intersections, regardless of number of networks
 			|| !cSC4NetworkTool::sNetworkTypeInfo[networkType].pylonSupportIDs.empty()
 			&& (cellInfo.edgeFlagsCombined & 0xf8f8f8f8) != 0 && numBasicConnsCombined == 2  // special higher-flag Lightrail/Monorail pieces
 			))
 		{
+			// flattening of intersections
 			uint32_t networkLotOffset = cellInfo.isNetworkLot != false ? 100000 : 0;
-			networkTool->InsertEqualityConstraint(cellInfo.vertexNW + networkLotOffset, cellInfo.vertexSW + networkLotOffset);
-			networkTool->InsertEqualityConstraint(cellInfo.vertexSW + networkLotOffset, cellInfo.vertexSE + networkLotOffset);
-			networkTool->InsertEqualityConstraint(cellInfo.vertexSE + networkLotOffset, cellInfo.vertexNE + networkLotOffset);
+			networkTool->InsertEqualityConstraint(cellInfo.vertices[NW] + networkLotOffset, cellInfo.vertices[SW] + networkLotOffset);
+			networkTool->InsertEqualityConstraint(cellInfo.vertices[SW] + networkLotOffset, cellInfo.vertices[SE] + networkLotOffset);
+			networkTool->InsertEqualityConstraint(cellInfo.vertices[SE] + networkLotOffset, cellInfo.vertices[NE] + networkLotOffset);
 		}
 		else
 		{
+			// slope and smoothness of straight network tiles (taking into account adjacent onslope pieces)
+			std::unordered_map<uint32_t, bool> cellIsOnslopeCache = {{mkCellXZ(cellInfo.x, cellInfo.z), onslopeSpec != nullptr}};
+			auto cellIsOnslope = [&networkTool, &cellIsOnslopeCache](uint32_t xz) {
+				if (auto search = cellIsOnslopeCache.find(xz); search != cellIsOnslopeCache.end()) {
+					return search->second;
+				} else {
+					auto adjCellInfo = networkTool->GetCellInfo(xz);
+					bool result = false;
+					if (adjCellInfo != nullptr && !adjCellInfo->isNetworkLot && isMultiType(*adjCellInfo)) {
+						auto adjNetwork1 = cSC4NetworkTool::GetFirstNetworkTypeFromFlags(adjCellInfo->networkTypeFlags);
+						auto adjNetwork2 = cSC4NetworkTool::GetFirstNetworkTypeFromFlags(adjCellInfo->networkTypeFlags & adjCellInfo->networkTypeFlags - 1);
+						result = onslopePieces.contains({
+								.networkTypeFlags = adjCellInfo->networkTypeFlags,
+								.edgeFlags1 = adjCellInfo->edgesPerNetwork[adjNetwork1],
+								.edgeFlags2 = adjCellInfo->edgesPerNetwork[adjNetwork2]});
+					}
+					cellIsOnslopeCache[xz] = result;
+					return result;
+				}
+			};
+
 			cSC4NetworkTool::tCrossSection csA, csB, csC;
 			bool isDiag;
 			for (int32_t dir = 0; dir < 4; dir++) {
@@ -84,11 +248,29 @@ namespace
 					auto slope = isDiag ? cSC4NetworkTool::sNetworkTypeInfo[networkType].slopeDiag : cSC4NetworkTool::sNetworkTypeInfo[networkType].slopeOrth;
 					auto smoothness = isDiag ? cSC4NetworkTool::sNetworkTypeInfo[networkType].smoothnessDiag : cSC4NetworkTool::sNetworkTypeInfo[networkType].smoothnessOrth;
 					networkTool->InsertEqualityConstraint(csA.vertex1, csA.vertex2);
-					networkTool->InsertEqualityConstraint(csB.vertex1, csB.vertex2);
-					networkTool->InsertEqualityConstraint(csC.vertex1, csC.vertex2);
-					networkTool->InsertSlopeConstraint(csB.vertex1, csA.vertex1, slope);
-					networkTool->InsertSlopeConstraint(csA.vertex1, csC.vertex1, slope);
-					networkTool->InsertSmoothnessConstraint(csB.vertex1, csA.vertex1, csC.vertex1, smoothness);
+
+					// check if adjacent piece is an OST in which case some constraints must be skipped
+					uint32_t xzB, xzC;
+					bool adjIsOnslopeB = false, adjIsOnslopeC = false;
+					// in orthogonal case, construct a diagonal cross section to determine a unique cell
+					if (diagCrossSectionToCellXZ(isDiag ? csB : (cSC4NetworkTool::tCrossSection {csA.vertex1, csB.vertex2}), networkTool->numCellsX, networkTool->numCellsZ, xzB)) {
+						adjIsOnslopeB = cellIsOnslope(xzB);
+					}
+					if (diagCrossSectionToCellXZ(isDiag ? csC : (cSC4NetworkTool::tCrossSection {csA.vertex1, csC.vertex2}), networkTool->numCellsX, networkTool->numCellsZ, xzC)) {
+						adjIsOnslopeC = cellIsOnslope(xzC);
+					}
+
+					if (!adjIsOnslopeB) {
+						networkTool->InsertEqualityConstraint(csB.vertex1, csB.vertex2);
+						networkTool->InsertSlopeConstraint(csB.vertex1, csA.vertex1, slope);
+					}
+					if (!adjIsOnslopeC) {
+						networkTool->InsertEqualityConstraint(csC.vertex1, csC.vertex2);
+						networkTool->InsertSlopeConstraint(csA.vertex1, csC.vertex1, slope);
+					}
+					if (!adjIsOnslopeB && !adjIsOnslopeC) {
+						networkTool->InsertSmoothnessConstraint(csB.vertex1, csA.vertex1, csC.vertex1, smoothness);
+					}
 				}
 			}
 		}

--- a/src/NetworkSlopes.cpp
+++ b/src/NetworkSlopes.cpp
@@ -8,6 +8,7 @@
 #include "RotFlip.h"
 
 #define NW_MASK(n) (1 << cISC4NetworkOccupant::eNetworkType::n)
+constexpr uint32_t allNetworksMask = 0x1fff;  // 13 networks
 
 struct IntersectionFlags {
 	uint32_t networkTypeFlags;
@@ -149,7 +150,7 @@ namespace
 	}
 
 	bool isMultiType(const cSC4NetworkCellInfo &cellInfo) {
-		return (cellInfo.networkTypeFlags & cellInfo.networkTypeFlags - 1) != 0;
+		return (cellInfo.networkTypeFlags & cellInfo.networkTypeFlags - 1 & allNetworksMask) != 0;
 	}
 
 	bool isPureDiag(uint32_t edgeFlags) {
@@ -202,7 +203,7 @@ namespace
 			auto networkType2 = cSC4NetworkTool::GetFirstNetworkTypeFromFlags(cellInfo.networkTypeFlags & cellInfo.networkTypeFlags - 1);
 			auto edgeFlags1 = cellInfo.edgesPerNetwork[networkType];
 			auto edgeFlags2 = cellInfo.edgesPerNetwork[networkType2];
-			IntersectionFlags key = {.networkTypeFlags = cellInfo.networkTypeFlags, .edgeFlags1 = edgeFlags1, .edgeFlags2 = edgeFlags2};
+			IntersectionFlags key = {.networkTypeFlags = cellInfo.networkTypeFlags & allNetworksMask, .edgeFlags1 = edgeFlags1, .edgeFlags2 = edgeFlags2};
 			if (auto search = onslopePieces.find(key); search != onslopePieces.end()) {
 				onslopeSpec = &search->second;
 				if (!onslopeSpec->firstIsMain) {
@@ -346,7 +347,7 @@ namespace
 						auto adjNetwork1 = cSC4NetworkTool::GetFirstNetworkTypeFromFlags(adjCellInfo->networkTypeFlags);
 						auto adjNetwork2 = cSC4NetworkTool::GetFirstNetworkTypeFromFlags(adjCellInfo->networkTypeFlags & adjCellInfo->networkTypeFlags - 1);
 						result = onslopePieces.contains({
-								.networkTypeFlags = adjCellInfo->networkTypeFlags,
+								.networkTypeFlags = adjCellInfo->networkTypeFlags & allNetworksMask,
 								.edgeFlags1 = adjCellInfo->edgesPerNetwork[adjNetwork1],
 								.edgeFlags2 = adjCellInfo->edgesPerNetwork[adjNetwork2]});
 					}

--- a/src/NetworkSlopes.cpp
+++ b/src/NetworkSlopes.cpp
@@ -78,19 +78,16 @@ namespace
 		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040004, 0x04010000}, {West, roadHtL2, false}},  // L2 RHW2 OST diag upper
 		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040004, 0x00030400}, {West, roadHtL2, false}},  // L2 RHW2 OST diag upper flipped
 		// Rail
-		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040404, 0x00020002}, {West, railHtL1,  true}},  // L1 Rail OST
-		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040402, 0x00020000}, {West, railHtL2,  true}},  // L2 Rail OST
-		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x04040400, 0x03010000}, {West, railHtL1,  true}},  // L1 Rail OST diag upper
-		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x04040400, 0x00030100}, {West, railHtL1,  true}},  // L1 Rail OST diag upper flipped
-		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00000304, 0x03010000}, {West, railHtL1,  true}},  // L1 Rail OST diag lower
-		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x01000004, 0x00030100}, {West, railHtL1,  true}},  // L1 Rail OST diag lower flipped
-		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x03040004, 0x00010000}, {West, railHtL2,  true}},  // L2 Rail OST diag upper
-		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040104, 0x00030000}, {West, railHtL2,  true}},  // L2 Rail OST diag upper flipped
-		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x00040301, 0x03010000}, {West, railHtL2,  true}},  // L2 Rail OST diag lower
-		{{NW_MASK(Rail)      | NW_MASK(DirtRoad),   0x01040003, 0x00030100}, {West, railHtL2,  true}},  // L2 Rail OST diag lower flipped
-		// HRW
-		{{NW_MASK(Rail)      | NW_MASK(Monorail),   0x04020402, 0x02040304}, {West, railHtL1,  true}},  // L1 HRW OST (orth and diag)
-		{{NW_MASK(Rail)      | NW_MASK(Monorail),   0x04020402, 0x01040204}, {West, railHtL2,  true}},  // L2 HRW OST (orth and diag)
+		{{NW_MASK(Rail)      | NW_MASK(Monorail),   0x00020404, 0x00000002}, {West, railHtL1,  true}},  // L1 Rail OST
+		{{NW_MASK(Rail)      | NW_MASK(Monorail),   0x00040402, 0x00020000}, {West, railHtL2,  true}},  // L2 Rail OST
+		{{NW_MASK(Rail)      | NW_MASK(Monorail),   0x04010400, 0x03040000}, {West, railHtL1,  true}},  // L1 Rail OST diag upper
+		{{NW_MASK(Rail)      | NW_MASK(Monorail),   0x04030400, 0x00040100}, {West, railHtL1,  true}},  // L1 Rail OST diag upper flipped
+		{{NW_MASK(Rail)      | NW_MASK(Monorail),   0x00000304, 0x03010000}, {West, railHtL1,  true}},  // L1 Rail OST diag lower
+		{{NW_MASK(Rail)      | NW_MASK(Monorail),   0x01000004, 0x00030100}, {West, railHtL1,  true}},  // L1 Rail OST diag lower flipped
+		{{NW_MASK(Rail)      | NW_MASK(Monorail),   0x03040004, 0x00010000}, {West, railHtL2,  true}},  // L2 Rail OST diag upper
+		{{NW_MASK(Rail)      | NW_MASK(Monorail),   0x00040104, 0x00030000}, {West, railHtL2,  true}},  // L2 Rail OST diag upper flipped
+		{{NW_MASK(Rail)      | NW_MASK(Monorail),   0x00040301, 0x03010000}, {West, railHtL2,  true}},  // L2 Rail OST diag lower
+		{{NW_MASK(Rail)      | NW_MASK(Monorail),   0x01040003, 0x00030100}, {West, railHtL2,  true}},  // L2 Rail OST diag lower flipped
 	};
 
 	std::unordered_map<IntersectionFlags, OnslopeSpec> initOnslopePiecesWithRotations() {

--- a/src/NetworkSlopes.h
+++ b/src/NetworkSlopes.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace NetworkSlopes
+{
+	void Install();
+}

--- a/src/NetworkStubs.h
+++ b/src/NetworkStubs.h
@@ -1,0 +1,129 @@
+#pragma once
+#include <cstdint>
+#include "cISC4NetworkOccupant.h"
+#include "SC4Vector.h"
+
+// The RESERVED macro provides names for reserved or unknown struct fields
+#define _CONCATNAM(x,y) x ## y
+#define _EXPANDNAM(x,y) _CONCATNAM(x,y)
+#define RESERVED _EXPANDNAM(reserved,__LINE__)
+
+const int32_t kNextX[] = {-1, 0, 1, 0};
+const int32_t kNextZ[] = {0, -1, 0, 1};
+
+class cSC4NetworkCellInfo
+{
+	public:
+		uint32_t x;
+		uint32_t z;
+		uint32_t networkTypeFlags;
+		cISC4NetworkOccupant* networkOccupant;
+		uint8_t RESERVED[0x8];
+		uint32_t edgesPerNetwork[13];
+		uint32_t edgeFlagsCombined;  // bitwise-or in case of 2 networks
+		uint8_t RESERVED[0x03];
+		bool isImmovable;
+		uint8_t RESERVED[2];
+		bool isNetworkLot;
+		uint8_t RESERVED[168-4-0x43-16];
+		int32_t vertexNW;  // vertex indices in contiguous (n+1)×(n+1) array where n is city size
+		int32_t vertexSW;
+		int32_t vertexSE;
+		int32_t vertexNE;
+		int32_t idxInCellsBuffer;
+};
+static_assert(offsetof(cSC4NetworkCellInfo, edgesPerNetwork) == 0x18);
+static_assert(offsetof(cSC4NetworkCellInfo, isImmovable) == 0x53);
+static_assert(offsetof(cSC4NetworkCellInfo, isNetworkLot) == 0x56);
+static_assert(offsetof(cSC4NetworkCellInfo, idxInCellsBuffer) == 0xb8);
+static_assert(sizeof(cSC4NetworkCellInfo) == 0xbc);
+
+class cSC4NetworkWorldCache
+{
+	public:
+		typedef cSC4NetworkCellInfo* (__thiscall* pfn_GetCell)(cSC4NetworkWorldCache* pThis, uint32_t xz);
+		inline cSC4NetworkCellInfo* GetCell(uint32_t xz) {
+			return reinterpret_cast<pfn_GetCell>(0x647a20)(this, xz);
+		}
+
+		uint8_t RESERVED[40];
+};
+static_assert(sizeof(cSC4NetworkWorldCache) == 0x28);
+
+class cSC4NetworkTypeInfo
+{
+	public:
+		uint8_t RESERVED[0xf0];
+		SC4Vector<uint32_t> pylonSupportIDs;
+		uint8_t RESERVED[0x4];
+		float slopeOrth;
+		float slopeDiag;
+		float smoothnessOrth;
+		float smoothnessDiag;
+		float sideSlope;
+};
+static_assert(offsetof(cSC4NetworkTypeInfo, slopeOrth) == 0x100);
+static_assert(sizeof(cSC4NetworkTypeInfo) == 0x114);
+
+class cSC4VertexHtConstraintSatisfier
+{
+	public:
+		typedef void (__thiscall* pfn_InsertSlopeConstraint)(cSC4VertexHtConstraintSatisfier* pThis, int32_t vertex1, int32_t vertex2, float slope);
+		static inline pfn_InsertSlopeConstraint InsertSlopeConstraint = reinterpret_cast<pfn_InsertSlopeConstraint>(0x65ff60);
+
+		uint8_t RESERVED[0x64];
+};
+static_assert(sizeof(cSC4VertexHtConstraintSatisfier) == 0x64);
+
+class cSC4NetworkTool
+{
+	public:
+		struct tCrossSection
+		{
+			int32_t vertex1;
+			int32_t vertex2;
+		};
+		static_assert(sizeof(tCrossSection) == 0x8);
+
+		static inline cSC4NetworkTypeInfo* const sNetworkTypeInfo = (reinterpret_cast<cSC4NetworkTypeInfo*>(0xb452c8));
+
+		typedef cISC4NetworkOccupant::eNetworkType (*pfn_GetFirstNetworkTypeFromFlags)(uint32_t networkTypeFlags);
+		static inline pfn_GetFirstNetworkTypeFromFlags GetFirstNetworkTypeFromFlags = reinterpret_cast<pfn_GetFirstNetworkTypeFromFlags>(0x623e60);
+
+		typedef void (__thiscall* pfn_InsertEqualityConstraint)(cSC4NetworkTool* pThis, int32_t vertex1, int32_t vertex2);
+		inline void InsertEqualityConstraint(int32_t vertex1, int32_t vertex2) {
+			return reinterpret_cast<pfn_InsertEqualityConstraint>(0x636000)(this, vertex1, vertex2);
+		}
+
+		typedef bool (__thiscall* pfn_GetCrossSections)(cSC4NetworkTool* pThis, cSC4NetworkCellInfo const &cellInfo, cISC4NetworkOccupant::eNetworkType networkType, int32_t direction,
+				cSC4NetworkTool::tCrossSection &mid, cSC4NetworkTool::tCrossSection &start, cSC4NetworkTool::tCrossSection &end, bool &isDiag);
+		inline bool GetCrossSections(cSC4NetworkCellInfo const &cellInfo, cISC4NetworkOccupant::eNetworkType networkType, int32_t direction,
+				cSC4NetworkTool::tCrossSection &mid, cSC4NetworkTool::tCrossSection &start, cSC4NetworkTool::tCrossSection &end, bool &isDiag) {
+			return reinterpret_cast<pfn_GetCrossSections>(0x636360)(this, cellInfo, networkType, direction, mid, start, end, isDiag);
+		}
+
+		void InsertSlopeConstraint(int32_t vertex1, int32_t vertex2, float slope) {
+			if (vertex1 >= 0 && vertex2 >= 0 && vertex1 != vertex2) {
+				cSC4VertexHtConstraintSatisfier::InsertSlopeConstraint(&this->vertexHtConstraintSatisfier1, vertex1, vertex2, slope);
+			}
+		}
+
+		typedef void (__thiscall* pfn_InsertSmoothnessConstraint)(cSC4NetworkTool* pThis, int32_t vertex1, int32_t vertex2, int32_t vertex3, float smoothness);
+		inline void InsertSmoothnessConstraint(int32_t vertex1, int32_t vertex2, int32_t vertex3, float smoothness) {
+			return reinterpret_cast<pfn_InsertSmoothnessConstraint>(0x636030)(this, vertex1, vertex2, vertex3, smoothness);
+		}
+
+		void* vtable;
+		intptr_t RESERVED[6];
+		cSC4NetworkWorldCache networkWorldCache;
+		uint8_t RESERVED[0x124 - 28 - 10*4];
+		cSC4VertexHtConstraintSatisfier vertexHtConstraintSatisfier1;
+		cSC4VertexHtConstraintSatisfier vertexHtConstraintSatisfier2;
+		uint8_t RESERVED[0x240 - 0x1ec];
+		uint32_t numCellsX;
+		uint32_t numCellsZ;
+		uint8_t RESERVED[0x270 - 0x248];
+};
+static_assert(offsetof(cSC4NetworkTool, networkWorldCache) == 0x1c);
+static_assert(offsetof(cSC4NetworkTool, vertexHtConstraintSatisfier1) == 0x124);
+static_assert(sizeof(cSC4NetworkTool) == 0x270);

--- a/src/NetworkStubs.h
+++ b/src/NetworkStubs.h
@@ -26,10 +26,7 @@ class cSC4NetworkCellInfo
 		uint8_t RESERVED[2];
 		bool isNetworkLot;
 		uint8_t RESERVED[168-4-0x43-16];
-		int32_t vertexNW;  // vertex indices in contiguous (n+1)×(n+1) array where n is city size
-		int32_t vertexSW;
-		int32_t vertexSE;
-		int32_t vertexNE;
+		int32_t vertices[4];  // NW, SW, SE, NE (see CellCorner): vertex indices in contiguous (n+1)×(n+1) array where n is city size
 		int32_t idxInCellsBuffer;
 };
 static_assert(offsetof(cSC4NetworkCellInfo, edgesPerNetwork) == 0x18);
@@ -111,6 +108,11 @@ class cSC4NetworkTool
 		typedef void (__thiscall* pfn_InsertSmoothnessConstraint)(cSC4NetworkTool* pThis, int32_t vertex1, int32_t vertex2, int32_t vertex3, float smoothness);
 		inline void InsertSmoothnessConstraint(int32_t vertex1, int32_t vertex2, int32_t vertex3, float smoothness) {
 			return reinterpret_cast<pfn_InsertSmoothnessConstraint>(0x636030)(this, vertex1, vertex2, vertex3, smoothness);
+		}
+
+		typedef cSC4NetworkCellInfo* (__thiscall* pfn_GetCellInfo)(cSC4NetworkTool* pThis, uint32_t xz);
+		inline cSC4NetworkCellInfo* GetCellInfo(uint32_t xz) {
+			return reinterpret_cast<pfn_GetCellInfo>(0x633220)(this, xz);
 		}
 
 		void* vtable;

--- a/src/Patching.h
+++ b/src/Patching.h
@@ -1,6 +1,12 @@
 #pragma once
 #include "stdint.h"
 
+#ifdef __clang__
+#define NAKED_FUN __attribute__((naked))
+#else
+#define NAKED_FUN __declspec(naked)
+#endif
+
 namespace Patching
 {
 	void OverwriteMemory(void* address, uint8_t newValue);

--- a/src/RotFlip.h
+++ b/src/RotFlip.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <cstdint>
+
+enum RotFlip : uint8_t { R0F0 = 0, R1F0 = 1, R2F0 = 2, R3F0 = 3, R0F1 = 0x80, R1F1 = 0x81, R2F1 = 0x82, R3F1 = 0x83 };
+
+static constexpr RotFlip rotFlipValues[] = { R0F0, R1F0, R2F0, R3F0, R0F1, R1F1, R2F1, R3F1 };
+
+static constexpr RotFlip rotate(RotFlip x, uint32_t rotation)
+{
+	return static_cast<RotFlip>((x + (0x1 | (x >> 6)) * (rotation & 0x3)) & 0x83);
+}
+
+static constexpr RotFlip relativeToAbsolute(RotFlip rf, uint32_t dir)
+{
+	return rotate(rf, 2+dir);
+}
+
+static constexpr RotFlip absoluteToRelative(RotFlip rf, uint32_t dir)
+{
+	return rotate(rf, 6-dir);
+}
+
+static constexpr RotFlip operator*(RotFlip x, RotFlip y)
+{
+	return static_cast<RotFlip>(rotate(x, y) ^ (y & 0x80));
+}
+
+static constexpr RotFlip rotate180(RotFlip rf)
+{
+	return static_cast<RotFlip>(rf ^ 0x2);
+}
+
+static constexpr RotFlip flipVertically(RotFlip rf)
+{
+	return static_cast<RotFlip>(rf ^ 0x82);
+}
+
+static constexpr RotFlip flipHorizontally(RotFlip rf)
+{
+	return static_cast<RotFlip>(rf ^ 0x80);
+}

--- a/src/RotFlip.h
+++ b/src/RotFlip.h
@@ -39,3 +39,8 @@ static constexpr RotFlip flipHorizontally(RotFlip rf)
 {
 	return static_cast<RotFlip>(rf ^ 0x80);
 }
+
+static constexpr bool isFlipped(RotFlip rf)
+{
+	return (rf & 0x80) != 0;
+}

--- a/src/cSC4NetworkTileConflictRule.h
+++ b/src/cSC4NetworkTileConflictRule.h
@@ -1,44 +1,6 @@
 #pragma once
 #include <cstdint>
-
-enum RotFlip : uint8_t { R0F0 = 0, R1F0 = 1, R2F0 = 2, R3F0 = 3, R0F1 = 0x80, R1F1 = 0x81, R2F1 = 0x82, R3F1 = 0x83 };
-
-static constexpr RotFlip rotFlipValues[] = { R0F0, R1F0, R2F0, R3F0, R0F1, R1F1, R2F1, R3F1 };
-
-static constexpr RotFlip rotate(RotFlip x, uint32_t rotation)
-{
-	return static_cast<RotFlip>((x + (0x1 | (x >> 6)) * (rotation & 0x3)) & 0x83);
-}
-
-static constexpr RotFlip relativeToAbsolute(RotFlip rf, uint32_t dir)
-{
-	return rotate(rf, 2+dir);
-}
-
-static constexpr RotFlip absoluteToRelative(RotFlip rf, uint32_t dir)
-{
-	return rotate(rf, 6-dir);
-}
-
-static constexpr RotFlip operator*(RotFlip x, RotFlip y)
-{
-	return static_cast<RotFlip>(rotate(x, y) ^ (y & 0x80));
-}
-
-static constexpr RotFlip rotate180(RotFlip rf)
-{
-	return static_cast<RotFlip>(rf ^ 0x2);
-}
-
-static constexpr RotFlip flipVertically(RotFlip rf)
-{
-	return static_cast<RotFlip>(rf ^ 0x82);
-}
-
-static constexpr RotFlip flipHorizontally(RotFlip rf)
-{
-	return static_cast<RotFlip>(rf ^ 0x80);
-}
+#include "RotFlip.h"
 
 struct Tile
 {

--- a/src/version.h
+++ b/src/version.h
@@ -20,6 +20,6 @@
 
 #pragma once
 
-#define PLUGIN_VERSION_STR      "1.1.1"
+#define PLUGIN_VERSION_STR      "1.1.1+slope"
 #define RESOURCE_VERSION         1,1,1,0
 #define RESOURCE_VERSION_STR    "1.1.1.0"


### PR DESCRIPTION
Implements custom slope constraints for

- vast majority of falsies (if they have a purely orthogonal or diagonal network and the other network has at least 2 flags),
- onslope transitions (RHW, viaducts, RRW, HRW),
- single-tile 45 degree curves (R0 and R1) and 90 degree curve (R1), except Lightrail/Monorail to avoid pillars sticking through the tracks

to make them more slope friendly.