### PR TITLE
remove static handle tile from FLEX pieces

### DIFF
--- a/src/FlexPieces.cpp
+++ b/src/FlexPieces.cpp
@@ -1,13 +1,87 @@
 #include "FlexPieces.h"
 #include "Patching.h"
 #include "NetworkStubs.h"
+#include "Logger.h"
+#include <limits>
+#include <tuple>
 
 namespace
 {
+	constexpr uint32_t vclAutoTileBase = 0x55387000;
 
-	void handleFlexPieceRul0(cSC4NetworkTool* networkTool, uint32_t x, uint32_t z, nSC4Networks::cIntRule &rule)
+	constexpr uint32_t cacheSize = 37;  // prime > 32 = typical tab-loop rotation count
+	std::tuple<uint32_t, SC4Point<int32_t>, cISC4NetworkOccupant::eNetworkType> sHidOriginCache[cacheSize];
+	std::tuple<uint32_t, SC4Point<int32_t>, cISC4NetworkOccupant::eNetworkType>* getCachedOrigin(uint32_t hid) {
+		auto item = &sHidOriginCache[hid % cacheSize];
+		return std::get<0>(*item) == hid ? item : nullptr;
+	}
+	void putCachedOrigin(uint32_t hid, SC4Point<int32_t> origin, cISC4NetworkOccupant::eNetworkType networkAtOrigin) {
+		sHidOriginCache[hid % cacheSize] = std::tuple(hid, origin, networkAtOrigin);
+	}
+
+	void handleFlexPieceRul0(cSC4NetworkTool* networkTool, uint32_t x, uint32_t z, nSC4Networks::cIntRule &rule, cISC4NetworkOccupant::eNetworkType &networkAtOrigin)
 	{
-		SC4Point<uint32_t> dummyCell = {x, z};  // simulates a 1×1-cell drag when placing the puzzle piece
+		// First, remove static cell from FLEX pieces
+		if (rule.autoTileBase == vclAutoTileBase && rule.staticCells.size() == 1 && rule.checkCells.size() > 1) {  // FLEX piece different from Eraser
+			// remove static cells from checkCells
+			for (auto sc = rule.staticCells.begin(); sc != rule.staticCells.end(); sc++) {
+				for (auto cc = rule.checkCells.begin(); cc != rule.checkCells.end(); ) {
+					if (sc->x == cc->cell.x && sc->y == cc->cell.y) {
+						cc = rule.checkCells.erase(cc);
+					} else {
+						cc++;
+					}
+				}
+				// TODO consider erasing static cell from rule.checkTypes as well
+			}
+			rule.staticCells.clear();  // non-optional tiles
+			rule.unnamedStaticCells.clear();  // `+`-letter tiles
+			for (auto pIdx = rule.constraints.begin(); pIdx != rule.constraints.end(); pIdx++) {
+				*pIdx = 0;  // no slope constraints
+			}
+			for (auto pIdx = rule.autoTileIndices.begin(); pIdx != rule.autoTileIndices.end(); pIdx++) {
+				*pIdx = 0;  // no static auto-tile pieces
+			}
+		}
+
+		// Next, fix handle-offset if puzzle piece origin does not point to a cell (e.g. when the static cell at FLEX piece origin has been removed)
+		SC4Point<int32_t> origin = {0, 0};
+		auto cachedItem = getCachedOrigin(rule.hid);
+		if (cachedItem != nullptr) {
+			origin = std::get<1>(*cachedItem);
+			networkAtOrigin = std::get<2>(*cachedItem);
+		} else {
+			bool foundOrigin = false;
+			for (auto cc = rule.checkCells.begin(); cc != rule.checkCells.end(); cc++) {
+				if (cc->cell.x == origin.x && cc->cell.y == origin.y) {
+					foundOrigin = true;
+					putCachedOrigin(rule.hid, origin, networkAtOrigin);
+					break;
+				}
+			}
+			if (!foundOrigin) {
+				// pick a different cell as new origin (one that is close to the origin, as this cell will not leave the map boundaries)
+				int32_t bestDist = std::numeric_limits<int32_t>::max();
+				for (auto cc = rule.checkCells.begin(); cc != rule.checkCells.end(); cc++) {
+					if (auto item = rule.checkTypes.find(cc->letter); item != rule.checkTypes.end()) {
+						int32_t dist = std::abs(cc->cell.x) + std::abs(cc->cell.y);
+						if (dist < bestDist) {
+							bestDist = dist;
+							origin.x = cc->cell.x;
+							origin.y = cc->cell.y;
+							networkAtOrigin = static_cast<cISC4NetworkOccupant::eNetworkType>(item->second.networks[0]);
+							putCachedOrigin(rule.hid, origin, networkAtOrigin);
+						}
+					}
+				}
+				if (origin.x == 0 && origin.y == 0) {  // something's wrong about this RUL0 entry
+					Logger& logger = Logger::GetInstance();
+					logger.WriteLineFormatted(LogLevel::Error, "Failed to fix the handle-offset of RUL0 HID 0x%08X due to unexpected CheckTypes or CellLayout.", rule.hid);
+				}
+			}
+		}
+
+		SC4Point<uint32_t> dummyCell = {x + origin.x, z + origin.y};  // simulates a 1×1-cell drag when placing the puzzle piece (now with the origin offset, it points to a cell contained in the puzzle piece)
 		networkTool->draggedCells.clear();
 		networkTool->draggedCells.push_back(dummyCell);
 	}
@@ -21,13 +95,15 @@ namespace
 			push eax;  // store
 			push ecx;  // store
 			push edx;  // store
+			lea eax, dword ptr [esp + 0x20 + 0xc];
 			mov ecx, dword ptr [esp + 0x78 + 0xc];
+			push eax;  // &networkAtOrigin
 			push ecx;  // cIntRule
 			push edx;  // z
 			push ebx;  // x
 			push esi;  // networkTool
 			call handleFlexPieceRul0;  // (cdecl)
-			add esp, 0x10;
+			add esp, 0x14;
 			pop edx;  // restore
 			pop ecx;  // restore
 			pop eax;  // restore
@@ -44,5 +120,5 @@ void FlexPieces::Install()
 	// Mainly for debugging, set fallback for network type at origin to Road instead of Highway,
 	// as Highway does not support placing single 1×1 tiles, leading to a red puzzle piece cursor
 	// in case something in this patch is wrong.
-	Patching::OverwriteMemory((void*)0x6099c4, (uint32_t)0);  // network type at origin = Road as fallback
+	Patching::OverwriteMemory((void*)0x6099c4, (uint32_t)cISC4NetworkOccupant::eNetworkType::Road);  // network type at origin = Road as fallback
 }

--- a/src/FlexPieces.cpp
+++ b/src/FlexPieces.cpp
@@ -1,0 +1,48 @@
+#include "FlexPieces.h"
+#include "Patching.h"
+#include "NetworkStubs.h"
+
+namespace
+{
+
+	void handleFlexPieceRul0(cSC4NetworkTool* networkTool, uint32_t x, uint32_t z, nSC4Networks::cIntRule &rule)
+	{
+		SC4Point<uint32_t> dummyCell = {x, z};  // simulates a 1×1-cell drag when placing the puzzle piece
+		networkTool->draggedCells.clear();
+		networkTool->draggedCells.push_back(dummyCell);
+	}
+
+	constexpr uint32_t InsertIsolatedHighwayIntersection_InjectPoint = 0x62cedc;
+	constexpr uint32_t InsertIsolatedHighwayIntersection_ReturnJump = 0x62cf42;
+
+	void NAKED_FUN Hook_InsertIsolatedHighwayIntersection(void)
+	{
+		__asm {
+			push eax;  // store
+			push ecx;  // store
+			push edx;  // store
+			mov ecx, dword ptr [esp + 0x78 + 0xc];
+			push ecx;  // cIntRule
+			push edx;  // z
+			push ebx;  // x
+			push esi;  // networkTool
+			call handleFlexPieceRul0;  // (cdecl)
+			add esp, 0x10;
+			pop edx;  // restore
+			pop ecx;  // restore
+			pop eax;  // restore
+			push InsertIsolatedHighwayIntersection_ReturnJump;
+			ret;
+		}
+	}
+}
+
+void FlexPieces::Install()
+{
+	Patching::InstallHook(InsertIsolatedHighwayIntersection_InjectPoint, Hook_InsertIsolatedHighwayIntersection);
+
+	// Mainly for debugging, set fallback for network type at origin to Road instead of Highway,
+	// as Highway does not support placing single 1×1 tiles, leading to a red puzzle piece cursor
+	// in case something in this patch is wrong.
+	Patching::OverwriteMemory((void*)0x6099c4, (uint32_t)0);  // network type at origin = Road as fallback
+}

--- a/src/FlexPieces.h
+++ b/src/FlexPieces.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace FlexPieces
+{
+	void Install();
+}

--- a/src/NAMDllDirector.cpp
+++ b/src/NAMDllDirector.cpp
@@ -47,6 +47,7 @@
 #include "Patching.h"
 #include "Rul2Engine.h"
 #include "NetworkSlopes.h"
+#include "FlexPieces.h"
 
 static constexpr uint32_t kNAMDllDirectorID = 0x4AC2AEFF;
 
@@ -248,6 +249,8 @@ noMatchingTunnelNetwork:
 			Rul2Engine::Install();
 			logger.WriteLine(LogLevel::Info, "Installing the Network Slopes patch.");
 			NetworkSlopes::Install();
+			logger.WriteLine(LogLevel::Info, "Installing the FLEX Puzzle Piece RUL0 patch.");
+			FlexPieces::Install();
 		}
 		catch (const wil::ResultException& e)
 		{

--- a/src/SC4HashMap.h
+++ b/src/SC4HashMap.h
@@ -1,0 +1,124 @@
+#pragma once
+
+template<typename Key, typename Value> class SC4HashMap
+{
+public:
+	struct HashMapNode
+	{
+		HashMapNode* next;
+		std::pair<const Key, Value> item;
+	};
+	static_assert(sizeof(HashMapNode) == 4 + ((sizeof(Key)-1)/4 + 1) * 4 + ((sizeof(Value)-1)/4 + 1) * 4);
+
+	// a vector of buckets each storing a singly-linked list of key-value pairs
+	HashMapNode** mpStart;
+	HashMapNode** mpEnd;
+	uint32_t RESERVED;  // probably capacity from SC4Vector
+	uint32_t mSize;
+
+private:
+	constexpr size_t get_hash_code(const Key& key) const { return key; }  // NOTE only supports unsigned integer types for now
+
+public:
+	size_t size() const {
+		// auto count = 0;
+		// for (auto pBucket = mpStart; pBucket != mpEnd; pBucket++) {
+		// 	for (auto pNode = *pBucket; pNode != nullptr; pNode = pNode->next) {
+		// 		count++;
+		// 	}
+		// }
+		// return count;
+		return mSize;
+	}
+
+	class iterator {
+		friend class SC4HashMap;
+		HashMapNode** pBucket;
+		HashMapNode** pEnd;
+		HashMapNode* pNode;
+		constexpr void advance_while_null() {
+			while (pNode == nullptr) {
+				pBucket++;
+				if (pBucket == pEnd) {
+					break;
+				} else {
+					pNode = *pBucket;
+				}
+			}
+		}
+	public:
+		iterator(HashMapNode** pBucket, HashMapNode** pEnd, HashMapNode* pNode) : pEnd(pEnd), pBucket(pBucket), pNode(pNode) {}
+		iterator(HashMapNode** pBucket, HashMapNode** pEnd) : pEnd(pEnd), pBucket(pBucket) {
+			if (pBucket != pEnd) {
+				this->pNode = *pBucket;
+				advance_while_null();
+			} else {
+				this->pNode = nullptr;
+			}
+		}
+		iterator& operator++() {
+			if (pNode != nullptr) {  // else no more elements
+				pNode = pNode->next;
+				advance_while_null();
+			}
+			return *this;
+		}
+		iterator operator++(int) { iterator retval = *this; ++(*this); return retval; }
+		bool operator==(iterator other) const { return pNode == other.pNode; }
+		bool operator!=(iterator other) const { return pNode != other.pNode; }
+		std::pair<const Key, Value>& operator*() const { return pNode->item; }
+		std::pair<const Key, Value>* operator->() const { return &(pNode->item); }
+	};
+
+	iterator begin() const { return iterator(mpStart, mpEnd); }
+	iterator end() const { return iterator(mpEnd, mpEnd, nullptr); }
+
+	Value& at(const Key& key) const {
+		if (mpEnd != mpStart) {
+			for (auto pNode = mpStart[get_hash_code(key) % (mpEnd - mpStart)]; pNode != nullptr; pNode = pNode->next) {
+				if (pNode->item.first == key) {
+					return pNode->item.second;
+				}
+			}
+		}
+		throw std::out_of_range("Key is not contained in map.");
+	}
+
+	iterator find(const Key& key) const {
+		if (mpEnd != mpStart) {
+			auto pBucket = mpStart + (get_hash_code(key) % (mpEnd - mpStart));
+			for (auto pNode = *pBucket; pNode != nullptr; pNode = pNode->next) {
+				if (pNode->item.first == key) {
+					return iterator(pBucket, mpEnd, pNode);
+				}
+			}
+		}
+		return end();
+	}
+
+	iterator erase(iterator pos) {
+		if (pos.pNode == nullptr) {  // end
+			return pos;
+		} else {
+			auto pNodePred = *(pos.pBucket);
+			if (pNodePred == pos.pNode) { // node was first in bucket, so drop it
+				(pos.pBucket)[0] = pos.pNode->next;
+				this->mSize = this->mSize - 1;
+			} else {
+				for (; pNodePred != nullptr; pNodePred = pNodePred->next) {
+					if (pNodePred->next == pos.pNode) {
+						pNodePred->next = pos.pNode->next;  // skip it
+						this->mSize = this->mSize - 1;
+						break;
+					}
+				}
+				// if end of loop is reached, pos did not contain valid data, as item is not contained in bucket
+			}
+			if (pos.pNode->next != nullptr) {
+				return iterator(pos.pBucket, pos.pEnd, pos.pNode->next);
+			} else {
+				return iterator(pos.pBucket + 1, pos.pEnd);
+			}
+		}
+	}
+};

--- a/src/version.h
+++ b/src/version.h
@@ -20,6 +20,6 @@
 
 #pragma once
 
-#define PLUGIN_VERSION_STR      "1.1.1+slope"
+#define PLUGIN_VERSION_STR      "1.1.1+slope+flex"
 #define RESOURCE_VERSION         1,1,1,0
 #define RESOURCE_VERSION_STR    "1.1.1.0"


### PR DESCRIPTION
This fixes the RUL0 puzzle piece placement such that the static handle tile of FLEX pieces doesn't have any impact on its surroundings anymore.

Additionally, this fixes a problem that could occur of the `<`/`^` symbols in RUL0 do not point to a tile (or to the now removed construction handle tile).

Moreover, this PR includes a very incomplete implementation of a Hash Map for SC4.