### PR TITLE
DirtRoad/RHW access patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -370,3 +370,8 @@ FodyWeavers.xsd
 
 # vcpkg repository build files
 vcpkg_installed/
+
+build/
+cmake-build-debug/
+cmake-build-release/
+cmake-build-minsizerel/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(NAM_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 set(NAM_SOURCES
     src/Check4GBPatch.cpp
     src/CommuteLoop.cpp
+    src/DirtRoadAccess.cpp
     src/FlexPieces.cpp
     src/Logger.cpp
     src/NAMDllDirector.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,108 @@
+cmake_minimum_required(VERSION 3.20)
+
+if(POLICY CMP0091)
+    cmake_policy(SET CMP0091 NEW)
+endif()
+
+if(CMAKE_GENERATOR MATCHES "Visual Studio" AND NOT DEFINED CMAKE_GENERATOR_PLATFORM)
+    set(CMAKE_GENERATOR_PLATFORM Win32 CACHE STRING "Target platform" FORCE)
+endif()
+
+project(NAMDll VERSION 1.3.0 LANGUAGES CXX RC)
+
+if(NOT WIN32)
+    message(FATAL_ERROR "NAM.dll is a Windows DLL and must be built for Win32.")
+endif()
+
+if(NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
+    message(FATAL_ERROR "NAM.dll must be built as 32-bit. Configure with -A Win32 when using Visual Studio.")
+endif()
+
+set(NAM_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
+
+set(NAM_SOURCES
+    src/Check4GBPatch.cpp
+    src/CommuteLoop.cpp
+    src/FlexPieces.cpp
+    src/Logger.cpp
+    src/NAMDllDirector.cpp
+    src/NetworkSlopes.cpp
+    src/Patching.cpp
+    src/RuleEquivalence.cpp
+    src/Rul2Engine.cpp
+    src/SC4VersionDetection.cpp
+    src/Settings.cpp
+    src/version.rc
+)
+
+set(GZCOM_SOURCES
+    vendor/gzcom-dll/gzcom-dll/src/cRZBaseString.cpp
+    vendor/gzcom-dll/gzcom-dll/src/cRZBaseVariant.cpp
+    vendor/gzcom-dll/gzcom-dll/src/cRZCOMDllDirector.cpp
+    vendor/gzcom-dll/gzcom-dll/src/cRZMessage2.cpp
+    vendor/gzcom-dll/gzcom-dll/src/cRZMessage2Standard.cpp
+    vendor/gzcom-dll/gzcom-dll/src/cS3DVector3.cpp
+    vendor/gzcom-dll/gzcom-dll/src/cSCBaseProperty.cpp
+)
+
+add_library(NAM SHARED ${NAM_SOURCES} ${GZCOM_SOURCES})
+
+target_compile_features(NAM PRIVATE cxx_std_20)
+
+target_include_directories(NAM PRIVATE
+    "${NAM_ROOT}/src"
+    "${NAM_ROOT}/vendor/gzcom-dll/gzcom-dll/include"
+    "${NAM_ROOT}/vendor/mINI/src"
+    "${NAM_ROOT}/vendor/wil/include"
+)
+
+target_compile_definitions(NAM PRIVATE
+    WIN32
+    _WINDOWS
+    _USRDLL
+    _WINDLL
+    UNICODE
+    _UNICODE
+    _CRT_SECURE_NO_WARNINGS
+)
+
+if(MSVC)
+    set_property(TARGET NAM PROPERTY
+        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
+    )
+
+    target_compile_options(NAM PRIVATE /W3 /EHsc /permissive-)
+    target_compile_options(NAM PRIVATE
+        "$<$<CONFIG:Release>:/O2;/Oi;/Gy>"
+        "$<$<CONFIG:RelWithDebInfo>:/O2;/Oi;/Gy>"
+        "$<$<CONFIG:MinSizeRel>:/O1;/Oi;/Gy>"
+    )
+
+    target_link_options(NAM PRIVATE
+        "$<$<CONFIG:Release>:/OPT:REF;/OPT:ICF>"
+        "$<$<CONFIG:RelWithDebInfo>:/OPT:REF;/OPT:ICF>"
+        "$<$<CONFIG:MinSizeRel>:/OPT:REF;/OPT:ICF>"
+    )
+endif()
+
+target_link_libraries(NAM PRIVATE version ole32)
+
+set_target_properties(NAM PROPERTIES
+    OUTPUT_NAME "NAM"
+    PREFIX ""
+    SUFFIX ".dll"
+)
+
+set(NAM_PLUGIN_DIR "$ENV{USERPROFILE}/Documents/SimCity 4/Plugins"
+    CACHE PATH "SimCity 4 Plugins directory used for post-build deployment"
+)
+
+if(NOT DEFINED ENV{CI})
+    add_custom_command(TARGET NAM POST_BUILD
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${NAM_PLUGIN_DIR}"
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+            "$<TARGET_FILE:NAM>"
+            "${NAM_PLUGIN_DIR}/$<TARGET_FILE_NAME:NAM>"
+        COMMENT "Deploying NAM.dll to ${NAM_PLUGIN_DIR}"
+    )
+endif()

--- a/src/DirtRoadAccess.cpp
+++ b/src/DirtRoadAccess.cpp
@@ -1,5 +1,6 @@
 #include "DirtRoadAccess.h"
 #include "Patching.h"
+#include "cISC4NetworkOccupant.h"
 
 namespace
 {
@@ -10,7 +11,7 @@ namespace
 
 	constexpr uint32_t kVanillaMotorizedVehicleNetworkMask = 0x00000449;
 	constexpr uint32_t kVanillaLowPrioFacingNetworkMask = 0x00000408;
-	constexpr uint32_t kDirtRoadNetworkMask = 1u << 11;
+	constexpr uint32_t kDirtRoadNetworkMask = 1u << cISC4NetworkOccupant::eNetworkType::DirtRoad;
 
 	constexpr uint32_t kAdjustedMotorizedVehicleNetworkMask = kVanillaMotorizedVehicleNetworkMask | kDirtRoadNetworkMask;
 	constexpr uint32_t kAdjustedLowPriorityFacingNetworkMask = kVanillaLowPrioFacingNetworkMask | kDirtRoadNetworkMask;

--- a/src/DirtRoadAccess.cpp
+++ b/src/DirtRoadAccess.cpp
@@ -1,0 +1,37 @@
+#include "DirtRoadAccess.h"
+#include "Patching.h"
+
+namespace
+{
+	constexpr uint32_t kGetLotFacingStreetCountNetworkMaskPushAddress = 0x004be6dc;
+	constexpr uint32_t kGetLotFacingStreetCountScoringMaskTestAddress = 0x004be70b;
+	constexpr uint32_t kFerryTerminalRoadAccessNetworkMaskPushAddress = 0x006c1726;
+	constexpr uint32_t kCalculateRoadAccessNetworkMaskPushAddress = 0x006c1bd1;
+
+	constexpr uint32_t kVanillaMotorizedVehicleNetworkMask = 0x00000449;
+	constexpr uint32_t kVanillaLowPrioFacingNetworkMask = 0x00000408;
+	constexpr uint32_t kDirtRoadNetworkMask = 1u << 11;
+
+	constexpr uint32_t kAdjustedMotorizedVehicleNetworkMask = kVanillaMotorizedVehicleNetworkMask | kDirtRoadNetworkMask;
+	constexpr uint32_t kAdjustedLowPriorityFacingNetworkMask = kVanillaLowPrioFacingNetworkMask | kDirtRoadNetworkMask;
+}
+
+void DirtRoadAccess::Install()
+{
+	Patching::PatchPushImmediate32(
+		kCalculateRoadAccessNetworkMaskPushAddress,
+		kVanillaMotorizedVehicleNetworkMask,
+		kAdjustedMotorizedVehicleNetworkMask);
+	Patching::PatchPushImmediate32(
+		kFerryTerminalRoadAccessNetworkMaskPushAddress,
+		kVanillaMotorizedVehicleNetworkMask,
+		kAdjustedMotorizedVehicleNetworkMask);
+	Patching::PatchPushImmediate32(
+		kGetLotFacingStreetCountNetworkMaskPushAddress,
+		kVanillaMotorizedVehicleNetworkMask,
+		kAdjustedMotorizedVehicleNetworkMask);
+	Patching::PatchTestEaxImmediate32(
+		kGetLotFacingStreetCountScoringMaskTestAddress,
+		kVanillaLowPrioFacingNetworkMask,
+		kAdjustedLowPriorityFacingNetworkMask);
+}

--- a/src/DirtRoadAccess.h
+++ b/src/DirtRoadAccess.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace DirtRoadAccess
+{
+	void Install();
+}

--- a/src/NAM.ini
+++ b/src/NAM.ini
@@ -1,7 +1,7 @@
 ; Optional configuration file for the NAM.dll, allowing to disable individual
 ; features for debugging purposes.
 ; Lines starting with semicolons are comments.
-; Supported values: true or false. By default, all features are activated.
+; Supported values: true or false. Unless stated otherwise, all features are activated by default.
 [Admin]
 ; Setting this to false stops the game from loading the DLL.
 Enabled=true
@@ -22,7 +22,7 @@ EnableNetworkSlopePatch=true
 EnableFlexPuzzlePiecePatch=true
 ; prevent eternal commuter loops between neighboring cities
 EnableCommuteLoopPatch=true
-; allow DirtRoad/RHW to satisfy stock road-access checks
-EnableDirtRoadAccessPatch=true
+; allow zones to develop along RHW networks (default: false)
+EnableDirtRoadAccessPatch=false
 ; keyboard shortcuts for Monorail, Onewayroad, Groundhighway and RHW
 EnableKeyboardShortcuts=true

--- a/src/NAM.ini
+++ b/src/NAM.ini
@@ -22,5 +22,7 @@ EnableNetworkSlopePatch=true
 EnableFlexPuzzlePiecePatch=true
 ; prevent eternal commuter loops between neighboring cities
 EnableCommuteLoopPatch=true
+; allow DirtRoad/RHW to satisfy stock road-access checks
+EnableDirtRoadAccessPatch=true
 ; keyboard shortcuts for Monorail, Onewayroad, Groundhighway and RHW
 EnableKeyboardShortcuts=true

--- a/src/NAMDllDirector.cpp
+++ b/src/NAMDllDirector.cpp
@@ -50,6 +50,7 @@
 #include "NetworkSlopes.h"
 #include "FlexPieces.h"
 #include "CommuteLoop.h"
+#include "DirtRoadAccess.h"
 
 static constexpr uint32_t kNAMDllDirectorID = 0x4AC2AEFF;
 
@@ -190,6 +191,7 @@ noMatchingTunnelNetwork:
 		InstallWhen(settings.enableNetworkSlopePatch, "Network Slopes patch", NetworkSlopes::Install);
 		InstallWhen(settings.enableFlexPuzzlePiecePatch, "FLEX Puzzle Piece RUL0 patch", FlexPieces::Install);
 		InstallWhen(settings.enableCommuteLoopPatch, "Eternal Commute Loop patch", CommuteLoop::Install);
+		InstallWhen(settings.enableDirtRoadAccessPatch, "DirtRoad/RHW Access patch", DirtRoadAccess::Install);
 	}
 }
 

--- a/src/Patching.cpp
+++ b/src/Patching.cpp
@@ -1,5 +1,7 @@
 #include "Patching.h"
+#include <cstring>
 #include <Windows.h>
+#include "wil/result_macros.h"
 #include "wil/win32_helpers.h"
 
 void Patching::OverwriteMemory(void* address, uint8_t newValue)
@@ -28,6 +30,42 @@ void Patching::OverwriteMemory(void* address, uint32_t newValue)
 
 	// Patch the memory at the specified address.
 	*((uint32_t*)address) = newValue;
+}
+
+void Patching::PatchImmediate32(const uint32_t address, const uint32_t expectedValue, const uint32_t newValue)
+{
+	auto* const immediate = reinterpret_cast<uint32_t*>(address);
+	if (*immediate == newValue)
+	{
+		return;
+	}
+
+	THROW_HR_IF(E_FAIL, *immediate != expectedValue);
+
+	DWORD oldProtect;
+	THROW_IF_WIN32_BOOL_FALSE(VirtualProtect(
+		immediate,
+		sizeof(newValue),
+		PAGE_EXECUTE_READWRITE,
+		&oldProtect));
+
+	std::memcpy(immediate, &newValue, sizeof(newValue));
+	FlushInstructionCache(GetCurrentProcess(), immediate, sizeof(newValue));
+	VirtualProtect(immediate, sizeof(newValue), oldProtect, &oldProtect);
+}
+
+void Patching::PatchPushImmediate32(const uint32_t address, const uint32_t expectedValue, const uint32_t newValue)
+{
+	const uint8_t* const instruction = reinterpret_cast<uint8_t*>(address);
+	THROW_HR_IF(E_FAIL, instruction[0] != 0x68);
+	PatchImmediate32(address + 1, expectedValue, newValue);
+}
+
+void Patching::PatchTestEaxImmediate32(const uint32_t address, const uint32_t expectedValue, const uint32_t newValue)
+{
+	const uint8_t* const instruction = reinterpret_cast<uint8_t*>(address);
+	THROW_HR_IF(E_FAIL, instruction[0] != 0xa9);
+	PatchImmediate32(address + 1, expectedValue, newValue);
 }
 
 void Patching::InstallHook(uint32_t address, void (*pfnFunc)(void))

--- a/src/Patching.cpp
+++ b/src/Patching.cpp
@@ -50,7 +50,6 @@ void Patching::PatchImmediate32(const uint32_t address, const uint32_t expectedV
 		&oldProtect));
 
 	std::memcpy(immediate, &newValue, sizeof(newValue));
-	FlushInstructionCache(GetCurrentProcess(), immediate, sizeof(newValue));
 	VirtualProtect(immediate, sizeof(newValue), oldProtect, &oldProtect);
 }
 

--- a/src/Patching.h
+++ b/src/Patching.h
@@ -11,6 +11,9 @@ namespace Patching
 {
 	void OverwriteMemory(void* address, uint8_t newValue);
 	void OverwriteMemory(void* address, uint32_t newValue);
+	void PatchImmediate32(uint32_t address, uint32_t expectedValue, uint32_t newValue);
+	void PatchPushImmediate32(uint32_t address, uint32_t expectedValue, uint32_t newValue);
+	void PatchTestEaxImmediate32(uint32_t address, uint32_t expectedValue, uint32_t newValue);
 
 	void InstallHook(uint32_t address, void (*pfnFunc)(void));
 }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -11,6 +11,7 @@ Settings::Settings() :
 	enableNetworkSlopePatch(true),
 	enableFlexPuzzlePiecePatch(true),
 	enableCommuteLoopPatch(true),
+	enableDirtRoadAccessPatch(true),
 	enableKeyboardShortcuts(true) {};
 
 void Settings::Load(std::filesystem::path settingsFilePath)
@@ -32,6 +33,7 @@ void Settings::Load(std::filesystem::path settingsFilePath)
 			readBoolProp("EnableNetworkSlopePatch", enableNetworkSlopePatch);
 			readBoolProp("EnableFlexPuzzlePiecePatch", enableFlexPuzzlePiecePatch);
 			readBoolProp("EnableCommuteLoopPatch", enableCommuteLoopPatch);
+			readBoolProp("EnableDirtRoadAccessPatch", enableDirtRoadAccessPatch);
 		} else {
 			logger.WriteLine(LogLevel::Info, "Using default settings, as no NAM.ini configuration file was detected.");
 		}

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -11,7 +11,7 @@ Settings::Settings() :
 	enableNetworkSlopePatch(true),
 	enableFlexPuzzlePiecePatch(true),
 	enableCommuteLoopPatch(true),
-	enableDirtRoadAccessPatch(true),
+	enableDirtRoadAccessPatch(false),
 	enableKeyboardShortcuts(true) {};
 
 void Settings::Load(std::filesystem::path settingsFilePath)

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -15,5 +15,6 @@ public:
 	bool enableNetworkSlopePatch;
 	bool enableFlexPuzzlePiecePatch;
 	bool enableCommuteLoopPatch;
+	bool enableDirtRoadAccessPatch;
 	bool enableKeyboardShortcuts;
 };


### PR DESCRIPTION
Adds a standalone DirtRoadAccess patch module, enabled by default via EnableDirtRoadAccessPatch=true.

The patch widens the game’s vanilla road-access network masks to include DirtRoad/RHW. It is wired into the existing NAM settings and patch installation flow, and adds a few Patching helpers to safely patch specific memory/instructions.

For my own comfort I added a CMakeLists.txt file so I can more easily build the DLL with CLion as well.